### PR TITLE
feat: Handle clicking specifications button to flip from front to back

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,12 @@ function renderCards(equipment) {
     );
 
     container.appendChild(card);
+
+    const currentEl = container.lastElementChild;
+    currentEl.querySelector('.specification-btn').addEventListener('click', () => {
+      const inner = currentEl.querySelector('.card-inner').classList;
+      inner.add('is-flipped');
+    });
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -332,12 +332,26 @@ select {
   margin-left: -30px;
 }
 
-.front {
-  display: block;
+.front,
+.back {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 }
 
 .back {
-  display: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  transform: rotateY(180deg);
+  margin: 10px 0;
+}
+
+.is-flipped {
+  transform: rotateY(180deg) !important;
 }
 
 .modal {


### PR DESCRIPTION
Handle clicking the full specifications button the front of the card to change the card to show the back of it. Added a CSS flip effect on click. 

Ref: https://github.com/Svjard/catcards/issues/13