### PR TITLE
feat: Handle dismissing the settings modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,24 @@ function initializeHandlers() {
   document.getElementById('settings').addEventListener('click', () => {
     toggleModalVisibility(true);
   });
+
+  document.getElementById('modal-close').addEventListener('click', () => {
+    toggleModalVisibility(false);
+  });
+
+  document.getElementById('modal-done').addEventListener('click', () => {
+    toggleModalVisibility(false);
+  });
+
+  // provide a way for the user to click away when the settings modal is
+  // shown and auto dismiss it
+  window.onclick = (event) => {
+    const modal = document.getElementById('settings-modal');
+
+    if (event.target === modal) {
+      toggleModalVisibility(false);
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
Handles dismissing the settings modal in three different ways:
- Clicking the (X) icon in the top-right hand side of the modal
- Clicking the Done button in the bottom center of the modal
- Or clicking outside of the modal anywhere else in the window

Ref: https://github.com/Svjard/catcards/issues/18